### PR TITLE
fix access count(*) comments

### DIFF
--- a/webapp/php/index.php
+++ b/webapp/php/index.php
@@ -130,6 +130,16 @@ $container->set('helper', function ($c) {
             $all_comments = $options['all_comments'];
 
             $posts = [];
+            $in_query = ''; // post_idのIN句を作るための変数
+            foreach ($result as $post) {
+                $in_query .= $post['id'] . ',';
+            }
+            $in_query = rtrim($in_query, ',');
+            // 一度にコメント数を取得するためのクエリを作成
+            $comment_counts = $this->fetch_first('SELECT COUNT(*) AS `count` FROM `comments` WHERE post_id in ($in_query) GROUP BY `post_id`');
+            $comment_counts->execute();
+            $comment_counts = $comment_counts->fetchAll(PDO::FETCH_ASSOC);
+
             foreach ($results as $post) {
                 $post['comment_count'] = $this->fetch_first('SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = ?', $post['id'])['count'];
                 $query = 'SELECT * FROM `comments` WHERE `post_id` = ? ORDER BY `created_at` DESC';


### PR DESCRIPTION
close #3

## What?（変更の概要・何を変更したのか）

https://github.com/ShotaArima/prtimes-pretask/blob/ef69cfbf7372f73dc84c06ab37b667b0958e0eda/webapp/php/index.php#L128-L138
- 上記のコードでは、`foreach`のループの中でデータベースのアクセスが毎度毎度行われている
- これを`foreach`の前にデータを取得し、アクセス回数による負荷を下げる


## Why?（なぜ変更するのか）

- この問題は、いわゆるN+1問題
- ループの中でデータベースへアクセスすることは、実行時間が長くなってしまう
- ベンチマークのタイムアウトの原因の一部なのではないかと予想

## How?（どう変更するのか）

- 事前にデータベースへのアクセスを行う
- `foreach`内では、適切な形で取得したデータを処理する

## Checklist

- [x] 事前にデータベースへのアクセスを行う
- [x] `foreach`内では、適切な形で取得したデータを処理する