### PR TITLE
Bug#7 allowed memory exhausted

### DIFF
--- a/webapp/php/index.php
+++ b/webapp/php/index.php
@@ -145,7 +145,6 @@ $container->set('helper', function ($c) {
             $comments->execute();
             $comments = $comments->fetchAll(PDO::FETCH_ASSOC);
 
-
             foreach ($results as $post) {
                 // $post['comment_count'] = $this->fetch_first('SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = ?', $post['id'])['count'];
                 $post['comment_count'] = 0;
@@ -155,7 +154,6 @@ $container->set('helper', function ($c) {
                         break;
                     }
                 }
-                
                 // $query = 'SELECT * FROM `comments` WHERE `post_id` = ? ORDER BY `created_at` DESC';
                 // if (!$all_comments) {
                 //     $query .= ' LIMIT 3';
@@ -167,6 +165,7 @@ $container->set('helper', function ($c) {
                         $post_comments[] = $comment;
                     }
                 }
+
                 foreach ($post_comments as $comment) {
                     $user_id = $comment['user_id'];
                     if (isset($user_map[$user_id])) {
@@ -178,8 +177,6 @@ $container->set('helper', function ($c) {
                 if (!$all_comments) {
                     $post_comments = array_slice($post_comments, 0, 3);
                 }
-
-
                 // $ps = $this->db()->prepare($query);
                 // $ps->execute([$post['id']]);
                 // $comments = $ps->fetchAll(PDO::FETCH_ASSOC);

--- a/webapp/php/index.php
+++ b/webapp/php/index.php
@@ -179,22 +179,6 @@ $container->set('helper', function ($c) {
                     $post_comments = array_slice($post_comments, 0, 3);
                 }
 
-                $post_comments = [];
-                foreach ($comments as $comment) {
-                    if ($comment['post_id'] === $post['id']) {
-                        $user_id = $comment['user_id'];
-                        if (isset($user_map[$user_id])) {
-                            $comment['user'] = $user_map[$user_id];
-                        }
-                        $post_comments[] = $comment;
-                        
-                        // 指定された数のコメントに達したら終了
-                        if (count($post_comments) >= 3) {
-                            break;
-                        }
-                    }
-                }
-
 
                 // $ps = $this->db()->prepare($query);
                 // $ps->execute([$post['id']]);


### PR DESCRIPTION
close #7

## What?（変更の概要・何を変更したのか）

- メモリの上限値オーバーが発生している
```
Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 20480 bytes) in /var/www/html/index.php on line 104
```


## Why?（なぜ変更するのか）

- 最初のクエリの実行箇所で起因している可能性がある

## How?（どう変更するのか）

- メモリの許容量に収まるようなクエリの実行を考える

## Checklist

- [ ] エラーの原因となる処理を見つける
- [ ] 許容量に収まるような処理にする