### PR TITLE
bug#10 Undefined post['user_name'] error

### DIFF
--- a/webapp/php/index.php
+++ b/webapp/php/index.php
@@ -184,7 +184,6 @@ $container->set('helper', function ($c) {
                     break;
                 }
             }
-            // var_dump($posts);
             return $posts;
         }
     };


### PR DESCRIPTION
close #10

## What?（変更の概要・何を変更したのか）

```
/var/www/html/views/post.php on line 22

Warning: Trying to access array offset on null in /var/www/html/views/post.php on line 22

Deprecated: rawurlencode(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/views/post.php on line 22
" class="isu-comment-account-name">
Warning: Undefined array key "user" in /var/www/html/views/post.php on line 22

Warning: Trying to access array offset on null in /var/www/html/views/post.php on line 22

Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/index.php on line 199
```
上記のようなエラーを解決する

## Why?（なぜ変更するのか）

- コメントのユーザネームについてクエリで実行できていないのでは？

## How?（どう変更するのか）

- コメントの名前を呼ぶクエリがあるのか探す。
- ない場合は記述、ある場合はそれをしっかり`$posts`に渡す

## Checklist

- [ ] コメントの名前を呼ぶクエリがあるのか探す。
- [ ] ない場合は記述、ある場合はそれをしっかり`$posts`に渡す